### PR TITLE
docs: Fix broken readme.md link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a template repo for creating a scanner plugin for [Copacetic](https://github.com/project-copacetic/copacetic).
 
-Learn more about Copacetic's scanner plugins [here](https://project-copacetic.github.io/copacetic/scanner-plugins).
+Learn more about Copacetic's scanner plugins [here](https://project-copacetic.github.io/copacetic/website/scanner-plugins).
 
 ## Development
 


### PR DESCRIPTION
Replaced the broken `scanner-plugins` Copacetic doc link with the working one.
